### PR TITLE
fix(base): Make home copy deletable

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1139,7 +1139,8 @@ RUN cp /usr/share/applications/firefox.desktop $HOME/Desktop/firefox.desktop && 
     chown jovyan:jovyan $HOME/Desktop/code.desktop
 
 # Workspace overwrite hotfix
-RUN cp -r /home/$NB_USER /home_nbuser_default
+RUN cp -r /home/$NB_USER /tmp/home_nbuser_default && \
+    chown -R $NB_USER /tmp/home_nbuser_default
 
 COPY init.sh /init.sh
 RUN chmod +x /init.sh

--- a/base/init.sh
+++ b/base/init.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cp -r --no-clobber /home_nbuser_default/. /home/$NB_USER/
-rm -rf /home_nbuser_default
+cp -r --no-clobber /tmp/home_nbuser_default/. /home/$NB_USER/
+rm -rf /tmp/home_nbuser_default
 export WORKSPACE_BASE_URL=${NB_PREFIX}
 exec python ${RESOURCES_PATH}/docker-entrypoint.py


### PR DESCRIPTION
A permission error was preventing the deletion of /home_nbuser_default (created while root but no longer root at runtime; also, write permission to parent directory required for directory deletion and user should not have write on /). Fixed by moving to /tmp/home_nbuser_default and giving recursive ownership of /tmp/home_nbuser_default to NB_USER.