### PR TITLE
refactor(rstudio): Install as root to match geomatics

### DIFF
--- a/geomatics/Dockerfile
+++ b/geomatics/Dockerfile
@@ -4,6 +4,6 @@ USER root
 
 RUN $RESOURCES_PATH/tools/qgis.sh
 
-USER jovyan
+USER $NB_USER
 
 CMD ["/init.sh"]

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -1,6 +1,10 @@
 FROM k8scc01covidacr.azurecr.io/ml-workspace-base:master
 
-RUN sudo $RESOURCES_PATH/tools/r-runtime.sh && \
-    sudo $RESOURCES_PATH/tools/r-studio-desktop.sh 
+USER root
+
+RUN $RESOURCES_PATH/tools/r-runtime.sh && \
+    $RESOURCES_PATH/tools/r-studio-desktop.sh 
+
+USER jovyan
 
 CMD ["/init.sh"]

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -5,6 +5,6 @@ USER root
 RUN $RESOURCES_PATH/tools/r-runtime.sh && \
     $RESOURCES_PATH/tools/r-studio-desktop.sh 
 
-USER jovyan
+USER $NB_USER
 
 CMD ["/init.sh"]


### PR DESCRIPTION
Will be part of removing sudo access to the primarily internal /resources/tools. Such access may be reinstated to a different user-installable folder in the future, but either way any separate images we keep should be in sync stylistically.