### PR TITLE
clean(access port): rm nonfunctional 'shareable link'

### DIFF
--- a/base/resources/jupyter/extensions/tooling-extension/jupyter_tooling/open-tools-widget.js
+++ b/base/resources/jupyter/extensions/tooling-extension/jupyter_tooling/open-tools-widget.js
@@ -19,7 +19,6 @@ define(['base/js/namespace', 'jquery', 'base/js/dialog', 'base/js/utils', 'requi
         var div = $('<div/>');
         var form = $('<form/>');
         div.append('<label style="width: 50px">Port: </label><input type="number" id="port-input" style="width: 200px" min="1" max="65535"><br>')
-        div.append('<br><label style="width: 120px">Get shareable link: </label><input type="checkbox" id="shareable-checkbox">')
         form.appendTo(div);
         return div;
     }
@@ -171,14 +170,7 @@ define(['base/js/namespace', 'jquery', 'base/js/dialog', 'base/js/utils', 'requi
                                     if (!portInput) {
                                         alert("Please input a valid port!")
                                     } else {
-                                        if ($('#shareable-checkbox').is(":checked")) {
-                                            path = basePath + "shared/tools/" + portInput + "/"
-                                            components.getShareableToken(path, function (data) {
-                                                window.open(path + "?token=" + String(data), '_blank');
-                                            });
-                                        } else {
-                                            window.open(basePath + "tools/" + portInput + "/", '_blank')
-                                        }
+                                        window.open(basePath + "tools/" + portInput + "/", '_blank')
                                     }
                                 }
                             }


### PR DESCRIPTION
While working on documentation per https://github.com/StatCan/daaas/issues/113, I discovered that the "get shareable link" option in the Access Port tool is nonfunctional. I have removed this option so as to not introduce any unnecessary confusion.

With how our Kubeflow RBAC is set up, whether or not the generated port access URL is the "shareable" version, logged-in contributors to the namespace can access it, while others cannot. 