### PR TITLE
feat: update vs code

### DIFF
--- a/base/resources/supervisor/programs/vscode.conf
+++ b/base/resources/supervisor/programs/vscode.conf
@@ -1,5 +1,5 @@
 [program:vscode]
-command=/usr/local/bin/code-server --port=8054 --disable-telemetry --user-data-dir=%(ENV_HOME)s/.config/Code/ --extensions-dir=%(ENV_HOME)s/.vscode/extensions/ --auth=none %(ENV_WORKSPACE_HOME)s/
+command=code-server --port=8054 --disable-telemetry --user-data-dir=%(ENV_HOME)s/.config/Code/ --extensions-dir=%(ENV_HOME)s/.vscode/extensions/ --auth=none %(ENV_WORKSPACE_HOME)s/
 autostart=true
 autorestart=true
 redirect_stderr=true 

--- a/base/resources/tools/vs-code-desktop.sh
+++ b/base/resources/tools/vs-code-desktop.sh
@@ -3,12 +3,13 @@
 # Stops script execution if a command has an error
 set -e
 
-SHA256=7b3bce26aff8677ae8920490709839dc6c5fda83728aec09724245761b64f217
+SHA256=6c117339d77b9593ad20b6eb4601ff7d0fd468922550d500edf07e3071e9a041
+VERSION=1.46.0
 
 if [ ! -f "/usr/share/code/code" ]; then
     echo "Installing VS Code. Please wait..."
     cd $RESOURCES_PATH
-    wget -q https://go.microsoft.com/fwlink/?LinkID=760868 -O ./vscode.deb
+    wget -q https://update.code.visualstudio.com/${VERSION}/linux-deb-x64/stable -O ./vscode.deb
     echo "${SHA256} ./vscode.deb" | sha256sum -c -
     apt-get update
     apt-get install -y ./vscode.deb

--- a/base/resources/tools/vs-code-server.sh
+++ b/base/resources/tools/vs-code-server.sh
@@ -3,23 +3,17 @@
 # Stops script execution if a command has an error
 set -e
 
-SHA256=545cb89dc9583a97af5db2988303e47676b8eb2b70fc9ad0292d5b298f24f02e
+SHA256=8f3b1d2cf439d2c685c21f3337320db6ca90aa6569a3b907d5c9a140e553f25e
 
 if [ ! -f "/usr/local/bin/code-server"  ]; then
     echo "Installing VS Code Server. Please wait..."
-    cd ${RESOURCES_PATH}
-    # CODE_SERVER_VERSION=2.1698
-    # VS_CODE_VERSION=$CODE_SERVER_VERSION-vsc1.41.1
-    # wget -q https://github.com/cdr/code-server/releases/download/$CODE_SERVER_VERSION/code-server$VS_CODE_VERSION-linux-x86_64.tar.gz -O ./vscode-web.tar.gz
-    # Use older version, since newer has some problems with python extension
-    VS_CODE_VERSION=2.1692-vsc1.39.2
-    wget -q https://github.com/cdr/code-server/releases/download/$VS_CODE_VERSION/code-server$VS_CODE_VERSION-linux-x86_64.tar.gz -O ./vscode-web.tar.gz
-    echo "${SHA256} ./vscode-web.tar.gz" | sha256sum -c -
-    tar xfz ./vscode-web.tar.gz
-    mv ./code-server$VS_CODE_VERSION-linux-x86_64/code-server /usr/local/bin
-    chmod -R a+rwx /usr/local/bin/code-server
-    rm ./vscode-web.tar.gz
-    rm -rf ./code-server$VS_CODE_VERSION-linux-x86_64
+    VERSION=3.4.1
+    wget -q "https://github.com/cdr/code-server/releases/download/v${VERSION}/code-server_${VERSION}_amd64.deb" -O ./vscode-web.deb
+    echo "${SHA256} ./vscode-web.deb" | sha256sum -c -
+    dpkg -i ./vscode-web.deb
+    rm ./vscode-web.deb
+
 else
     echo "VS Code Server is already installed"
 fi
+


### PR DESCRIPTION
Resolves https://github.com/StatCan/kubeflow-containers/issues/60 

Note that #10 also changes `vs-code-desktop.sh` in order to pass a new checksum and build. That is because the original code uses a download link that always gets the latest version (and will thus fail an older checksum and stop the build for every update). In case of a merge conflict, the `vs-code-desktop.sh` from this PR should be used, which specifies a version.

Note that due to a change in installation directories as part of the `vs-code-server.sh` update, the file `resources/supervisor/programs/vscode.conf` has changed. However, in #10, as part of streamlining supervisor configuration*, the directory `resources/supervisor/programs` has been renamed to `resources/supervisor/conf.d` to better reflect its ultimate destination of `/etc/supervisor/conf.d` inside the image. In case of a merge conflict:
1. Use `resources/supervisor/programs/vscode.conf` from this PR to replace `resources/supervisor/conf.d/vscode.conf` in #10, but keep the location as `resources/supervisor/conf.d/vscode.conf`.
2. Use all the other supervisor program `.conf` files from #10, keeping their locations in `resources/supervisor/conf.d/`. 
3. Delete `resources/supervisor/programs/`.

*I was considering adding that streamlining here (at least as far as the directory change), but the original supervisor-related code is very chaotic (e.g. defined across multiple layers) and wrapped up in various permissions considerations. I concluded that doing so could actually be *more* confusing and create further merge conflicts.