### PR TITLE
feat: add ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,92 @@
+# This workflow will build a docker container, publish it to Azure Container Registry, and deploy it to Azure Kubernetes Service using a helm chart.
+#
+# https://github.com/Azure/actions-workflow-samples/tree/master/Kubernetes
+#
+# To configure this workflow:
+#
+# 1. Set up the following secrets in your workspace:
+#     a. REGISTRY_USERNAME with ACR username
+#     b. REGISTRY_PASSWORD with ACR Password
+#     c. AZURE_CREDENTIALS with the output of `az ad sp create-for-rbac --sdk-auth`
+#
+# 2. Change the values for the REGISTRY_NAME, CLUSTER_NAME, CLUSTER_RESOURCE_GROUP and NAMESPACE environment variables (below).
+name: build
+on:
+  push:
+    branches:
+      - master
+
+# Environment variables available to all jobs and steps in this workflow
+env:
+  REGISTRY_NAME: k8scc01covidacr
+  CLUSTER_NAME: k8s-cancentral-01-covid-aks
+  CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+
+    # Connect to Azure Container registry (ACR)
+    - uses: azure/docker-login@v1
+      with:
+        login-server: ${{ env.REGISTRY_NAME }}.azurecr.io
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
+
+    # Container build and push to a Azure Container registry (ACR)
+    - run: |
+        # Remote Desktop Base
+        docker build -f base/Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-base:${{ github.sha }} .
+        docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-base:${{ github.sha }}
+        docker tag ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-base:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-web-app:${GITHUB_REF#refs/*/}
+        docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-base:${GITHUB_REF#refs/*/}
+        docker system prune -f -a
+
+    # Scan image for vulnerabilities
+    - uses: Azure/container-scan@v0
+      with:
+        image-name: ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-base:${{ github.sha }}
+        severity-threshold: CRITICAL
+        run-quality-checks: false
+
+    # Container build and push to a Azure Container registry (ACR)
+    - run: |
+        # Remote Desktop R
+        docker build -f r/Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-r:${{ github.sha }} .
+        docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-r:${{ github.sha }}
+        docker tag ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-r:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-web-app:${GITHUB_REF#refs/*/}
+        docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-r:${GITHUB_REF#refs/*/}
+        docker system prune -f -a
+
+    # Scan image for vulnerabilities
+    - uses: Azure/container-scan@v0
+      with:
+        image-name: ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-r:${{ github.sha }}
+        severity-threshold: CRITICAL
+        run-quality-checks: false
+
+    # Container build and push to a Azure Container registry (ACR)
+    - run: |
+        # Remote Desktop Base
+        docker build -f geomatics/Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-geomatics:${{ github.sha }} .
+        docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-geomatics:${{ github.sha }}
+        docker tag ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-geomatics:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-web-app:${GITHUB_REF#refs/*/}
+        docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-geomatics:${GITHUB_REF#refs/*/}
+        docker system prune -f -a
+
+    # Scan image for vulnerabilities
+    - uses: Azure/container-scan@v0
+      with:
+        image-name: ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-geomatics:${{ github.sha }}
+        severity-threshold: CRITICAL
+        run-quality-checks: false
+    

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     # Container build and push to a Azure Container registry (ACR)
     - run: |
         # Remote Desktop Base
-        docker build -f base/Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-base:${{ github.sha }} .
+        docker build -f base/Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-base:${{ github.sha }} base
         docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-base:${{ github.sha }}
         docker tag ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-base:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-web-app:${GITHUB_REF#refs/*/}
         docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-base:${GITHUB_REF#refs/*/}
@@ -61,7 +61,7 @@ jobs:
     # Container build and push to a Azure Container registry (ACR)
     - run: |
         # Remote Desktop R
-        docker build -f r/Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-r:${{ github.sha }} .
+        docker build -f r/Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-r:${{ github.sha }} r
         docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-r:${{ github.sha }}
         docker tag ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-r:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-web-app:${GITHUB_REF#refs/*/}
         docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-r:${GITHUB_REF#refs/*/}
@@ -77,7 +77,7 @@ jobs:
     # Container build and push to a Azure Container registry (ACR)
     - run: |
         # Remote Desktop Base
-        docker build -f geomatics/Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-geomatics:${{ github.sha }} .
+        docker build -f geomatics/Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-geomatics:${{ github.sha }} geomatics
         docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-geomatics:${{ github.sha }}
         docker tag ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-geomatics:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-web-app:${GITHUB_REF#refs/*/}
         docker push ${{ env.REGISTRY_NAME }}.azurecr.io/remote-desktop-geomatics:${GITHUB_REF#refs/*/}


### PR DESCRIPTION
Resolves https://github.com/StatCan/kubeflow-containers/issues/62 

Question: this is based on https://github.com/StatCan/kubeflow-containers/blob/master/.github/workflows/build.yml. However, therein there is a difference in the `docker build` line for some images.

For example, minimal-notebook ends in **.** : `docker build -f minimal-notebook/cpu/Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/minimal-notebook-cpu:${{ github.sha }} .`

But base-notebook ends in **base-notebook/cpu**: `docker build -f base-notebook/cpu/Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/base-notebook-cpu:${{ github.sha }} base-notebook/cpu`

I would like to confirm what this difference means, and thus if it should be applied anywhere here (e.g. `remote-desktop/r`?)