### PR TITLE
feat(security): checksum RStudio

### DIFF
--- a/base/resources/tools/r-studio-desktop.sh
+++ b/base/resources/tools/r-studio-desktop.sh
@@ -3,12 +3,17 @@
 # Stops script execution if a command has an error
 set -e
 
+VERSION=1.2.5033
+RELEASE=xenial
+SHA256=a1591ed7fd84d4e7ed57f1e7dc5306bfc0279d8369d3ea613b78a37c9c8938f0
+
 if ! hash rstudio 2>/dev/null; then
     echo "Installing RStudio Desktop. Please wait..."
     cd $RESOURCES_PATH
     apt-get update
     #apt-get install --yes r-base
-    wget https://download1.rstudio.org/desktop/xenial/amd64/rstudio-1.2.5033-amd64.deb -O ./rstudio.deb
+    wget https://download1.rstudio.org/desktop/${RELEASE}/amd64/rstudio-${VERSION}-amd64.deb -O ./rstudio.deb
+    echo "${SHA256} ./rstudio.deb" | sha256sum -c -
     # ld library path makes problems
     LD_LIBRARY_PATH="" gdebi --non-interactive ./rstudio.deb
     rm ./rstudio.deb


### PR DESCRIPTION
This checksum was missed in the first pass, seems to be the only one though.

Note: while here I took a look at updating RStudio, but changing either the Ubuntu release (to bionic given that this is an Ubuntu 18 base) or the version number results in crashes. I figure this would need to be a more complex procedure in conjunction with r-runtime updates.