### PR TITLE
feat(novnc): autoconnect to vnc

### DIFF
--- a/base/resources/home/.workspace/tools/01-novnc.json
+++ b/base/resources/home/.workspace/tools/01-novnc.json
@@ -1,6 +1,6 @@
 {
     "id": "vnc-link",
     "name": "VNC",
-    "url_path": "/tools/vnc/?password=vncpassword",
+    "url_path": "/tools/vnc/?autoconnect=true&password=vncpassword",
     "description": "Desktop GUI for the workspace"
 }


### PR DESCRIPTION
Before this change, when a user opens the VNC tool, they are brought to an intermediary screen where they have to click `Connect`. This change skips that extra screen/click and instead brings them directly into the VNC session.