### PR TITLE
fix(filebrowser): Loading hotfix

### DIFF
--- a/base/resources/home/.workspace/tools/08-filebrowser.json
+++ b/base/resources/home/.workspace/tools/08-filebrowser.json
@@ -1,6 +1,6 @@
 {
     "id": "filebrowser-link",
     "name": "Filebrowser",
-    "url_path": "/shared/filebrowser/files/home/jovyan/",
+    "url_path": "/shared/filebrowser/files/home/jovyan/?token=admin",
     "description": "Browse and manage workspace files"
 }


### PR DESCRIPTION
I thought this part was unnecessary, but it actually breaks Filebrowser with a `Please provide a valid API token via token get parameter` error down the line. I'm not 100% sure why this is effect is very delayed; I think the token might be saved as a cookie that will eventually expire. To the extent of my experimentation, I am not aware of this granting any undue privileges, given that access is ultimately controlled by authentication to Kubeflow and RBAC (e.g. namespace collaborators).

Discovered during work on https://github.com/StatCan/kubeflow-containers/issues/38 but ultimately unrelated