### PR TITLE
clean: Fix indent, netdata config near install

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -510,9 +510,12 @@ RUN \
 ## netdata
 
 RUN \
- /bin/bash $RESOURCES_PATH/tools/netdata.sh --install && \
+    /bin/bash $RESOURCES_PATH/tools/netdata.sh --install && \
     # Cleanup
- clean-layer.sh
+    clean-layer.sh
+
+# Configure netdata
+#COPY resources/netdata/ /etc/netdata/
 
 ## Glances webtool is installed in python section below
 
@@ -667,9 +670,6 @@ RUN \
     cp -f $RESOURCES_PATH/branding/favicon.ico $RESOURCES_PATH"/filebrowser/img/icons/favicon-32x32.png" && \
     cp -f $RESOURCES_PATH/branding/favicon.ico $RESOURCES_PATH"/filebrowser/img/icons/favicon-16x16.png" && \
     cp -f $RESOURCES_PATH/branding/ml-workspace-logo.svg $RESOURCES_PATH"/filebrowser/img/logo.svg"
-
-# Configure netdata
-#COPY resources/netdata/ /etc/netdata/
 
 # Configure Matplotlib
 RUN \


### PR DESCRIPTION
Fixes an indent in the netdata install and moves the netdata configuration next to it. The netdata configuration is presently commented out (and the folder in question no longer exists) as we are going for default configuration for this version. The comment is left as a reference (and now in a more appropriate location) should that change in the future.