### PR TITLE
Remove and update vscode extensions

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -759,4 +759,3 @@ USER ${NB_USER}
 EXPOSE 8888
 
 CMD ["/init.sh"] 
-

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -552,50 +552,25 @@ COPY \
 # Install vscode extension
 # https://github.com/cdr/code-server/issues/171
 # Alternative install: /usr/local/bin/code-server --user-data-dir=$HOME/.config/Code/ --extensions-dir=$HOME/.vscode/extensions/ --install-extension ms-python-release && \
-ARG SHA256py=1b5f276b5f75824b4689a95aa580c3f8954bda1921180212b06a2a7183e72a26
-ARG SHA256gl=45ecbe5db4c14add5cabde2eb33ddf1ff6c8d3993a62c72dea38ca9f2e8eab02
-ARG SHA256cr=8d9f0d25921bb9515870aa055b9e8a799cf76ad4630ac3a9a7469df5bc479368
-ARG SHA256esl=2085177971f97ed88a021f349def005672add65d9884c22d12c4d3074be5b41d
-ARG SHA256mdl=ba1d87efc12434828692cd1a215c04f3f73500a424ab5deb4a5e16ff045f9a96
+ARG SHA256py=62327bf119880f0ffe0a4ca3dc61371c73ed6a2481c79ab60b0163a3fd072128
+ARG SHA256gl=ed130b2a0ddabe5132b09978195cefe9955a944766a72772c346359d65f263cc
 RUN \
     cd $RESOURCES_PATH && \
     mkdir -p $HOME/.vscode/extensions/ && \
     # Install python extension - (newer versions are 30MB bigger)
-    VS_PYTHON_VERSION="2020.1.58038" && \
+    VS_PYTHON_VERSION="2020.6.91350" && \
     wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix && \
     echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - && \
     bsdtar -xf ms-python-release.vsix extension && \
     rm ms-python-release.vsix && \
     mv extension $HOME/.vscode/extensions/ms-python.python-$VS_PYTHON_VERSION && \
     # Install git lens: https://github.com/eamodio/vscode-gitlens
-    VS_GITLENS_VERSION="10.2.0" && \
+    VS_GITLENS_VERSION="10.2.2" && \
     wget --quiet --no-check-certificate https://github.com/eamodio/vscode-gitlens/releases/download/v$VS_GITLENS_VERSION/gitlens-$VS_GITLENS_VERSION.vsix && \
     echo "${SHA256gl} gitlens-${VS_GITLENS_VERSION}.vsix" | sha256sum -c - && \
     bsdtar -xf gitlens-$VS_GITLENS_VERSION.vsix extension && \
     rm gitlens-$VS_GITLENS_VERSION.vsix && \
     mv extension $HOME/.vscode/extensions/eamodio.gitlens-$VS_GITLENS_VERSION && \
-    # Install code runner: https://github.com/formulahendry/vscode-code-runner/releases/latest
-    VS_CODE_RUNNER_VERSION="0.9.15" && \
-    wget --quiet --no-check-certificate https://github.com/formulahendry/vscode-code-runner/releases/download/$VS_CODE_RUNNER_VERSION/code-runner-$VS_CODE_RUNNER_VERSION.vsix && \
-    echo "${SHA256cr} code-runner-${VS_CODE_RUNNER_VERSION}.vsix" | sha256sum -c - && \
-    bsdtar -xf code-runner-$VS_CODE_RUNNER_VERSION.vsix extension && \
-    rm code-runner-$VS_CODE_RUNNER_VERSION.vsix && \
-    mv extension $HOME/.vscode/extensions/code-runner-$VS_CODE_RUNNER_VERSION && \
-    # Install ESLint extension: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
-    # Older versions do not support vscode 1.39 - https://github.com/microsoft/vscode-eslint/
-    VS_ESLINT_VERSION="1.9.1" && \
-    wget --quiet --no-check-certificate https://marketplace.visualstudio.com/_apis/public/gallery/publishers/dbaeumer/vsextensions/vscode-eslint/$VS_ESLINT_VERSION/vspackage -O dbaeumer.vscode-eslint.vsix && \
-    echo "${SHA256esl} dbaeumer.vscode-eslint.vsix" | sha256sum -c - && \
-    bsdtar -xf dbaeumer.vscode-eslint.vsix extension && \
-    rm dbaeumer.vscode-eslint.vsix && \
-    mv extension $HOME/.vscode/extensions/dbaeumer.vscode-eslint-$VS_ESLINT_VERSION.vsix && \
-    # Install Markdown lint extension: https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint
-    VS_MARKDOWN_LINT_VERSION="0.33.0" && \
-    wget --quiet --no-check-certificate https://marketplace.visualstudio.com/_apis/public/gallery/publishers/DavidAnson/vsextensions/vscode-markdownlint/$VS_MARKDOWN_LINT_VERSION/vspackage -O davidanson.vscode-markdownlint.vsix && \
-    echo "${SHA256mdl} davidanson.vscode-markdownlint.vsix" | sha256sum -c - && \
-    bsdtar -xf davidanson.vscode-markdownlint.vsix extension && \
-    rm davidanson.vscode-markdownlint.vsix && \
-    mv extension $HOME/.vscode/extensions/davidanson.vscode-markdownlint-$VS_MARKDOWN_LINT_VERSION.vsix && \
     # Fix permissions
     fix-permissions.sh $HOME/.vscode/extensions/ && \
     # Cleanup
@@ -784,3 +759,4 @@ USER ${NB_USER}
 EXPOSE 8888
 
 CMD ["/init.sh"] 
+


### PR DESCRIPTION
Resolves https://github.com/StatCan/kubeflow-containers/issues/80

Removed the Code Runner, ESLint, and MarkdownLint extensions from VSCode.

Updated the GitLens and Python extensions to latest versions.