### PR TITLE
fix(pdf): set Firefox as the default PDF viewer

### DIFF
--- a/base/resources/home/.config/mimeapps.list
+++ b/base/resources/home/.config/mimeapps.list
@@ -1,3 +1,8 @@
 [Default Applications]
 application/x-shellscript=exo-terminal-emulator.desktop
 text/plain=code.desktop;
+application/pdf=firefox.desktop
+
+[Added Associations]
+application/pdf=userapp-firefox-Y32KO0.desktop;firefox.desktop;
+


### PR DESCRIPTION
Resolves https://github.com/StatCan/kubeflow-containers-desktop/issues/33

Sets Firefox as the default application to view/open any PDF files.