### PR TITLE
fix(landing_page): visual alignment

### DIFF
--- a/base/resources/landing_page/index.html
+++ b/base/resources/landing_page/index.html
@@ -30,8 +30,7 @@
               src="icons/jupyter.svg"
               alt="Jupyter"
             />
-            Jupyter
-            <!-- Replace with or add JupyterLab? -->
+            Jupyter Notebook
           </a>
         </div>
       </div>

--- a/base/resources/landing_page/style.css
+++ b/base/resources/landing_page/style.css
@@ -24,7 +24,6 @@ h4 {
   grid-row-gap: 20px;
   grid-column-gap: 20px;
   justify-items: stretch;
-  justify-content: center;
 }
 
 .interfaces > div,
@@ -32,10 +31,9 @@ h4 {
   border: 2px solid #999999;
   border-radius: 5px;
   background-color: #eeeeee;
-  padding: 1em 2em;
+  padding: 1em;
   color: #333333;
   display: flex;
-  justify-content: center;
   align-items: center;
   font-size: 40px;
   text-align: center;
@@ -67,7 +65,6 @@ h4 {
   padding: 1em 2em;
   color: #333333;
   display: flex;
-  justify-content: center;
   align-items: center;
   font-size: 30px;
 }
@@ -96,8 +93,7 @@ h4 {
 
 #launcher-icon-jupyter {
   width: 100px;
-  height: 100px;
-  padding-right: 10px;
+  padding-right: 15px;
 }
 
 .launcher-icon {


### PR DESCRIPTION
Relates to https://github.com/StatCan/kubeflow-containers/issues/38

While doing a final review of the landing page prior to submitting the image to the manifest, I saw that there are some alignment issues:

- The Jupyter icon is squashed
- The Jupyter and NoVNC icons have very different positions and spacing
- The In-Browser Tools icons and labels have inconsistent positions

I am proposing a few minor CSS changes to correct this. The only change to the HTML is renaming "Jupyter" to "Jupyter Notebook", both because that requires no further changes to become consistent with its similar length neighbour "Remote Desktop", and to clarify for users that this is only Jupyter Notebook and _not_ JupyterLab as in other images.

Original:

![image](https://user-images.githubusercontent.com/13685849/90439291-521aca80-e0a3-11ea-9ed0-e1c3236bf64a.png)

Proposed fix:

![image](https://user-images.githubusercontent.com/13685849/90439376-77a7d400-e0a3-11ea-9a6f-3d24bd795c37.png)
