### PR TITLE
feat: i18n for jupyter

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -754,6 +754,17 @@ ARG START_RSYSLOGD="/usr/sbin/rsyslogd -n"
 RUN \
     echo "${NB_USER} ALL=(ALL) NOPASSWD: ${START_CRON}, ${START_NETDATA}, ${START_RSYSLOGD}" >> /etc/sudoers.d/${NB_USER}
 
+# Install the French Locale. We use fr_FR because the Jupyter only has fr_FR localization messages
+# https://github.com/jupyter/notebook/tree/master/notebook/i18n/fr_FR/LC_MESSAGES
+RUN \
+    apt-get update && \
+    apt-get install -y locales && \
+    sed -i -e 's/# fr_FR.UTF-8 UTF-8/fr_FR.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    clean-layer.sh
+
+
 ### Workspace overwrite hotfix
 RUN cp -r /home/$NB_USER /home_nbuser_default && \
     chown -R $NB_USER /home_nbuser_default

--- a/base/resources/jupyter/start-notebook.sh
+++ b/base/resources/jupyter/start-notebook.sh
@@ -4,6 +4,14 @@
 
 set -e
 
+# Set language based on argv. Change later to use env variable
+argvFile=$(</home/jovyan/.config/Code/User/argv.json)
+if [[ $argvFile == *'"locale":"fr"'* ]]; then
+  export LANGUAGE=fr_FR
+  else
+  export LANGUAGE=en_EN
+fi
+
 if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
   # launched by JupyterHub, use single-user entrypoint
   exec /usr/local/bin/start-singleuser.sh "$@"

--- a/base/resources/scripts/languagecheck.js
+++ b/base/resources/scripts/languagecheck.js
@@ -30,10 +30,10 @@ http
     function setLanguageJson(callback) {
       readJsonFile(function detectLangSwitch(err, content) {
         let JSON_DATA = JSON.parse(content);
-        if (JSON_DATA.locale === lang){
-          return callback(null, "No language switch needed");
+        if (JSON_DATA.locale === lang) {
+          return callback(null, "No language switch needed", false);
         }
-        
+
         JSON_DATA.locale = lang;
 
         fs.writeFile(
@@ -41,23 +41,63 @@ http
           JSON.stringify(JSON_DATA),
           function (err) {
             if (err) {
-              return callback(new Error("Error writing to file:"+err));
+              return callback(new Error("Error writing to file:" + err));
             }
-            callback(null, "Language file set to:" + lang);
+            callback(null, "Language file set to:" + lang, true);
           }
         );
       });
     }
 
-    setLanguageJson(function (err, returnMsg) {
-      if (err){
-        console.log(err.toString()); //write to supervisor process
-        res.writeHead(500, { "Content-Type": "text/plain" });
-        return res.end(err.toString());
+    // Set up language for VSCode and Jupyter
+    setLanguageJson(function (err, returnMsg, switchLanguage) {
+      if (err) {
+        createResponse(500,err.toString());
       }
-      console.log(returnMsg);
-      res.writeHead(200, { "Content-Type": "text/plain" });
-      res.end(returnMsg);
+      // Create a string to be used to create the landing page
+      let info = returnMsg;
+
+      if (switchLanguage) {
+        killJupyterProcesss(function (jupyterError, jupyterResult) {
+          if (jupyterError) {
+            createResponse(500,jupyterError.toString());
+          }
+          info = info + "\n" + jupyterResult;
+          createResponse(200,info);
+        });
+      } else {
+        createResponse(200,info);
+      }
     });
+
+    // Used to create the response on the page and write to the log
+    function createResponse(responseCode, responseText){
+      console.log(responseText)
+      res.writeHead(responseCode, {"Content-Type": "text/plain"});
+      res.end(responseText);
+    }
+
+    //Used to kill the jupyter process, supervisor will restart it
+    function killJupyterProcesss(callback) {
+      const { exec } = require("child_process");
+      exec("jupyter notebook stop 8090", (error, stdout, stderr) => {
+        if (error) {
+          return callback(
+            new Error(
+              "Error executing command stop notebook on 8090:" + error.message
+            )
+          );
+        }
+        if (stderr.length > 0) {
+          // if something happens during jupyter notebook stop 8090
+          return callback(new Error("Command execution error:" + stderr));
+        }
+        callback(
+          null,
+          "Restarting Jupyter Notebook to change language:" + stdout
+        );
+      });
+    }
   })
   .listen(42536);
+


### PR DESCRIPTION
Resolves #48 
-Install the French language locale in the environment
-Upon notebook starting, the locale from the argv file is taken and used as the "Language" ENV variable.
-For changes to be applied, the onload of the landing page must be hit to trigger a restart of jupyter.
-The onload handles the changing of the locale in argv (vscode changes)
-Currently the browser must be in fr_FR for **everything** to get translated
 In fr_CA, a few widgets in jupyter notebook are not translated like "Save" and "Run"
-This is weird to me as all translations seemingly come from the [nbui](https://github.com/jupyter/notebook/blob/master/notebook/i18n/fr_FR/LC_MESSAGES/nbui.po)  from fr_FR/LC_MESSAGES in jupyter notebook. 
The widget values exist in that file, but in fr_CA they do not get applied.
Comparing this to say "Clusters tab..." which **does get translated in fr_CA** this makes less sense to me

This contains changes from my branch for VSCODE, when that is merged in to master I can rebase this off of that. 
The changes are to `languagecheck.js` (new file from vscode changes) and `start-notebook.sh`, as well as the Dockerfile to install the French locale

[Video demonstrating France French and Canadian French](https://youtu.be/QPsvuDbu3mY)