### PR TITLE
Switch to conda-forge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ name: build
 on:
   push:
     branches:
-      - Switch-to-conda-forge
+      - master
 
 # Environment variables available to all jobs and steps in this workflow
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ name: build
 on:
   push:
     branches:
-      - master
+      - Switch-to-conda-forge
 
 # Environment variables available to all jobs and steps in this workflow
 env:

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -251,30 +251,46 @@ COPY resources/tools $RESOURCES_PATH/tools
 
 ### RUNTIMES ###
 
-# Install Miniconda: https://repo.continuum.io/miniconda/
-# Also moved DATA SCIENCE BASICS and the Conda Solving Environemnt fix here: 
-# All base conda in one layer brings down image size
+# Install Miniforge
+
 ENV \
     CONDA_DIR=/opt/conda \
-    PYTHON_VERSION="3.7.7" \
-    CONDA_PYTHON_DIR=/opt/conda/lib/python3.7 \
-    CONDA_VERSION="4.7.12"
-ARG SHA256=a23fcffe97690d3bbcd34cda798c3a3318e0f35d863c5d4aca3fc983fe8450b7
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -O ${HOME}/miniconda.sh && \
-    echo "${SHA256} ${HOME}/miniconda.sh" | sha256sum -c - && \
-    /bin/bash ~/miniconda.sh -b -p $CONDA_DIR && \
+    PYTHON_VERSION="3.8.5" \
+    CONDA_PYTHON_DIR=/opt/conda/lib/python3.8 \
+    CONDA_VERSION="4.9.0"
+
+# Miniforge installer patch version
+ARG miniforge_patch_number="4"
+# Miniforge installer architecture
+ARG miniforge_arch="x86_64"
+# Python implementation to use 
+# can be either Miniforge3 to use Python or Miniforge-pypy3 to use PyPy
+ARG miniforge_python="Miniforge3"
+
+# Miniforge archive to install
+ARG miniforge_version="${CONDA_VERSION}-${miniforge_patch_number}"
+# Miniforge installer
+ARG miniforge_installer="${miniforge_python}-${miniforge_version}-Linux-${miniforge_arch}.sh"
+# Miniforge checksum
+ARG miniforge_checksum="dae28a05f0fcfed0b47c66468e8434ab42cb1ff90de96540a506949cdecd2b5a"
+
+RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/${miniforge_installer}" && \
+    echo "${miniforge_checksum} *${miniforge_installer}" | sha256sum --check && \
+    /bin/bash "${miniforge_installer}" -f -b -p $CONDA_DIR && \
     export PATH=$CONDA_DIR/bin:$PATH && \
-    rm ~/miniconda.sh && \
+    rm "${miniforge_installer}" && \
     # Update conda
     $CONDA_DIR/bin/conda update -y -n base -c defaults conda && \
     $CONDA_DIR/bin/conda update -y setuptools && \
     $CONDA_DIR/bin/conda install -y conda-build && \
     # Add conda forge - Append so that conda forge has lower priority than the main channel
-    $CONDA_DIR/bin/conda config --system --append channels conda-forge && \
+    $CONDA_DIR/bin/conda config --add channels conda-forge && \
+    #$CONDA_DIR/bin/conda config --system --append channels conda-forge && \
+    $CONDA_DIR/bin/conda config --set channel_priority strict && \
     $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
     $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
     ## Conda Solving Environment Fix: Turn off channel priority
-    conda config --set channel_priority false && \
+    ##conda config --set channel_priority true && \
     # Update selected packages - install python 3.7.x
     $CONDA_DIR/bin/conda install -y --update-all python=$PYTHON_VERSION && \
     # Link Conda

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -48,8 +48,8 @@ RUN \
 COPY resources/scripts/clean-layer.sh  /usr/bin/clean-layer.sh
 COPY resources/scripts/fix-permissions.sh  /usr/bin/fix-permissions.sh
 
- # Make clean-layer and fix-permissions executable
- RUN \
+# Make clean-layer and fix-permissions executable
+RUN \
     chmod u+x /usr/bin/clean-layer.sh && \
     chmod u+x /usr/bin/fix-permissions.sh
 
@@ -75,108 +75,108 @@ RUN \
     apt-get install -y sudo apt-utils && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-        # This is necessary for apt to access HTTPS sources: 
-        apt-transport-https \
-        gnupg-agent \
-        gpg-agent \
-        gnupg2 \
-        ca-certificates \
-        build-essential \
-        pkg-config \
-        software-properties-common \
-        lsof \
-        net-tools \
-        libcurl4 \
-        curl \
-        wget \
-        cron \
-        openssl \
-        iproute2 \
-        psmisc \
-        tmux \
-        dpkg-sig \
-        uuid-dev \
-        csh \
-        xclip \
-        clinfo \
-        libgdbm-dev \
-        libncurses5-dev \
-        gawk \
-        # Simplified Wrapper and Interface Generator (5.8MB) - required by lots of py-libs
-        swig \
-        # Graphviz (graph visualization software) (4MB)
-        graphviz libgraphviz-dev \
-        # Terminal multiplexer
-        screen \
-        # Editor
-        nano \
-        # Find files
-        locate \
-        # Dev Tools
-        # sqlite3 \
-        # XML Utils
-        xmlstarlet \
-        #  R*-tree implementation - Required for earthpy, geoviews (3MB)
-        libspatialindex-dev \
-        # Search text and binary files
-        yara \
-        # Minimalistic C client for Redis
-        libhiredis-dev \
-        libleptonica-dev \
-        # GEOS library (3MB)
-        libgeos-dev \
-        # style sheet preprocessor
-        less \
-        # Print dir tree
-        tree \
-        # Bash autocompletion functionality
-        bash-completion \
-        # ping support
-        iputils-ping \
-        # Json Processor
-        jq \
-        rsync \
-        # VCS:
-        git \
-        subversion \
-        jed \
-        # odbc drivers
-        unixodbc unixodbc-dev \
-        # Image support
-        libtiff-dev \
-        libjpeg-dev \
-        libpng-dev \
-        # TODO: no 18.04 installation candidate: libjasper-dev \
-        libglib2.0-0 \
-        libxext6 \
-        libsm6 \
-        libxext-dev \
-        libxrender1 \
-        libzmq3-dev \
-        # protobuffer support
-        protobuf-compiler \
-        libprotobuf-dev \
-        libprotoc-dev \
-        autoconf \
-        automake \
-        libtool \
-        cmake  \
-        fonts-liberation \
-        google-perftools \
-        # Compression Libs
-        # also install rar/unrar? but both are propriatory or unar (40MB)
-        zip \
-        gzip \
-        unzip \
-        bzip2 \
-        lzop \
-        bsdtar \
-        zlibc \
-        # unpack (almost) everything with one command
-        unp \
-        libbz2-dev \
-        liblzma-dev \
-        zlib1g-dev && \
+    # This is necessary for apt to access HTTPS sources: 
+    apt-transport-https \
+    gnupg-agent \
+    gpg-agent \
+    gnupg2 \
+    ca-certificates \
+    build-essential \
+    pkg-config \
+    software-properties-common \
+    lsof \
+    net-tools \
+    libcurl4 \
+    curl \
+    wget \
+    cron \
+    openssl \
+    iproute2 \
+    psmisc \
+    tmux \
+    dpkg-sig \
+    uuid-dev \
+    csh \
+    xclip \
+    clinfo \
+    libgdbm-dev \
+    libncurses5-dev \
+    gawk \
+    # Simplified Wrapper and Interface Generator (5.8MB) - required by lots of py-libs
+    swig \
+    # Graphviz (graph visualization software) (4MB)
+    graphviz libgraphviz-dev \
+    # Terminal multiplexer
+    screen \
+    # Editor
+    nano \
+    # Find files
+    locate \
+    # Dev Tools
+    # sqlite3 \
+    # XML Utils
+    xmlstarlet \
+    #  R*-tree implementation - Required for earthpy, geoviews (3MB)
+    libspatialindex-dev \
+    # Search text and binary files
+    yara \
+    # Minimalistic C client for Redis
+    libhiredis-dev \
+    libleptonica-dev \
+    # GEOS library (3MB)
+    libgeos-dev \
+    # style sheet preprocessor
+    less \
+    # Print dir tree
+    tree \
+    # Bash autocompletion functionality
+    bash-completion \
+    # ping support
+    iputils-ping \
+    # Json Processor
+    jq \
+    rsync \
+    # VCS:
+    git \
+    subversion \
+    jed \
+    # odbc drivers
+    unixodbc unixodbc-dev \
+    # Image support
+    libtiff-dev \
+    libjpeg-dev \
+    libpng-dev \
+    # TODO: no 18.04 installation candidate: libjasper-dev \
+    libglib2.0-0 \
+    libxext6 \
+    libsm6 \
+    libxext-dev \
+    libxrender1 \
+    libzmq3-dev \
+    # protobuffer support
+    protobuf-compiler \
+    libprotobuf-dev \
+    libprotoc-dev \
+    autoconf \
+    automake \
+    libtool \
+    cmake  \
+    fonts-liberation \
+    google-perftools \
+    # Compression Libs
+    # also install rar/unrar? but both are propriatory or unar (40MB)
+    zip \
+    gzip \
+    unzip \
+    bzip2 \
+    lzop \
+    bsdtar \
+    zlibc \
+    # unpack (almost) everything with one command
+    unp \
+    libbz2-dev \
+    liblzma-dev \
+    zlib1g-dev && \
     # configure dynamic linker run-time bindings
     ldconfig && \
     # Fix permissions
@@ -194,13 +194,13 @@ RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.18.0/tini 
 RUN \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        openssh-client \
-        openssh-server \
-        # SSLH for SSH + HTTP(s) Multiplexing
-        sslh \
-        # SSH Tooling
-        autossh \
-        mussh && \
+    openssh-client \
+    openssh-server \
+    # SSLH for SSH + HTTP(s) Multiplexing
+    sslh \
+    # SSH Tooling
+    autossh \
+    mussh && \
     chmod go-w $HOME && \
     mkdir -p $HOME/.ssh/ && \
     # create empty config file if not exists
@@ -285,13 +285,11 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
     $CONDA_DIR/bin/conda install -y conda-build && \
     # Add conda forge - Append so that conda forge has lower priority than the main channel
     $CONDA_DIR/bin/conda config --add channels conda-forge && \
-    #$CONDA_DIR/bin/conda config --system --append channels conda-forge && \
     $CONDA_DIR/bin/conda config --set channel_priority strict && \
     $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
     $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
     ## Conda Solving Environment Fix: Turn off channel priority
-    ##conda config --set channel_priority true && \
-    # Update selected packages - install python 3.7.x
+    # Update selected packages - install python 3.8.x
     $CONDA_DIR/bin/conda install -y --update-all python=$PYTHON_VERSION && \
     # Link Conda
     ln -s $CONDA_DIR/bin/python /usr/local/bin/python && \
@@ -308,42 +306,42 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
     pip install --upgrade pip && \
     conda install -y --update-all nomkl && \
     conda install -y --update-all \
-            'python='$PYTHON_VERSION \
-            tqdm \
-            pyzmq \
-            cython \
-            graphviz \
-            numpy \
-            matplotlib \
-            scipy \
-            requests \
-            urllib3 \
-            pandas \
-            six \
-            future \
-            protobuf \
-            zlib \
-            boost \
-            psutil \
-            PyYAML \
-            python-crontab \
-            ipykernel \
-            cmake \
-            joblib \
-            Pillow \
-            ipython \
-            notebook \
-            # Selected by library evaluation
-            networkx \
-            click \
-            docutils \
-            imageio \
-            tabulate \
-            flask \
-            dill \
-            regex \
-            toolz \
-            jmespath && \
+    'python='$PYTHON_VERSION \
+    tqdm \
+    pyzmq \
+    cython \
+    graphviz \
+    numpy \
+    matplotlib \
+    scipy \
+    requests \
+    urllib3 \
+    pandas \
+    six \
+    future \
+    protobuf \
+    zlib \
+    boost \
+    psutil \
+    PyYAML \
+    python-crontab \
+    ipykernel \
+    cmake \
+    joblib \
+    Pillow \
+    ipython \
+    notebook \
+    # Selected by library evaluation
+    networkx \
+    click \
+    docutils \
+    imageio \
+    tabulate \
+    flask \
+    dill \
+    regex \
+    toolz \
+    jmespath && \
     # OpenMPI support
     apt-get install -y --no-install-recommends libopenmpi-dev openmpi-bin && \
     # Install numba


### PR DESCRIPTION
Set` conda-forge` as a default channel to install `conda` and we use `Miniforge` as a installer..  I also upgrade the version of python to be availabe in that channel. 